### PR TITLE
Update gl-s10_v2.yaml to change clk_mode to clk

### DIFF
--- a/gl-s10_v2.yaml
+++ b/gl-s10_v2.yaml
@@ -26,7 +26,7 @@ ethernet:
   type: IP101
   mdc_pin: GPIO23
   mdio_pin: GPIO18
-  clk_mode: GPIO0_IN
+  clk: GPIO0_IN
   phy_addr: 1
   power_pin: GPIO5
 


### PR DESCRIPTION
Got the following warning in the ESPHome Builder: _"The 'clk_mode' option is deprecated and will be removed in ESPHome 2026.1. Please update your configuration to use 'clk' instead."_

I updated the Yaml code to reflect the proposed change.