### PR TITLE
Refactor clk_mode to clk with pin and mode

### DIFF
--- a/gl-s10_v2.yaml
+++ b/gl-s10_v2.yaml
@@ -26,7 +26,9 @@ ethernet:
   type: IP101
   mdc_pin: GPIO23
   mdio_pin: GPIO18
-  clk_mode: GPIO0_IN
+  clk:
+    pin: GPIO0
+    mode: CLK_EXT_IN
   phy_addr: 1
   power_pin: GPIO5
 


### PR DESCRIPTION
Clk_mode is deprecated as of version 2026.1